### PR TITLE
tests: use English area names in mock fixtures

### DIFF
--- a/custom_components/sevi_cloud/fan.py
+++ b/custom_components/sevi_cloud/fan.py
@@ -80,7 +80,7 @@ class SeviCloudFan(SeviCloudAreaEntity, FanEntity):
             area_label,
             entity_key="fan",
         )
-        # The entity name is the area label (e.g. "Schlafzimmer").
+        # The entity name is the area label as configured in the SEC Smart app (e.g. "Bedroom").
         self._attr_name = area_label
 
     # ------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,12 +38,12 @@ MOCK_DEVICE_DATA = {
     "id": TEST_DEVICE_ID,
     "name": "Test Home",
     "areas": {
-        "area1": {"label": "Kein Name", "mode": "INACTIVE "},
-        "area2": {"label": "Kein Name", "mode": "INACTIVE "},
-        "area3": {"label": "Kein Name", "mode": "INACTIVE "},
-        "area4": {"label": "Schlafzimmer", "mode": "Manual 1"},
-        "area5": {"label": "Kinderzimmer", "mode": "Manual 2"},
-        "area6": {"label": "Wohnzimmer", "mode": "Manual 1"},
+        "area1": {"label": "No Name", "mode": "INACTIVE "},
+        "area2": {"label": "No Name", "mode": "INACTIVE "},
+        "area3": {"label": "No Name", "mode": "INACTIVE "},
+        "area4": {"label": "Bedroom", "mode": "Manual 1"},
+        "area5": {"label": "Kids Room", "mode": "Manual 2"},
+        "area6": {"label": "Living Room", "mode": "Manual 1"},
     },
     "telemetry": {
         "restFilterTime": 42,

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -23,9 +23,9 @@ from .conftest import MOCK_COORDINATOR_DATA, TEST_API_KEY, TEST_DEVICE_ID
 CONFIG_DATA = {CONF_API_KEY: TEST_API_KEY}
 
 # Entity IDs: HA prefixes with device name because _attr_has_entity_name=True.
-FAN_SCHLAFZIMMER = "fan.test_home_schlafzimmer"
-FAN_KINDERZIMMER = "fan.test_home_kinderzimmer"
-FAN_WOHNZIMMER = "fan.test_home_wohnzimmer"
+FAN_BEDROOM = "fan.test_home_bedroom"
+FAN_KIDS_ROOM = "fan.test_home_kids_room"
+FAN_LIVING_ROOM = "fan.test_home_living_room"
 
 
 async def _setup(hass: HomeAssistant):
@@ -47,7 +47,7 @@ async def _setup(hass: HomeAssistant):
 async def test_fan_entities_created(hass: HomeAssistant) -> None:
     """One fan entity per active area should be registered."""
     await _setup(hass)
-    for entity_id in (FAN_SCHLAFZIMMER, FAN_KINDERZIMMER, FAN_WOHNZIMMER):
+    for entity_id in (FAN_BEDROOM, FAN_KIDS_ROOM, FAN_LIVING_ROOM):
         state = hass.states.get(entity_id)
         assert state is not None, f"Missing entity: {entity_id}"
 
@@ -55,7 +55,7 @@ async def test_fan_entities_created(hass: HomeAssistant) -> None:
 async def test_fan_initial_state(hass: HomeAssistant) -> None:
     """Fan is on and shows the correct preset from coordinator data."""
     await _setup(hass)
-    state = hass.states.get(FAN_SCHLAFZIMMER)
+    state = hass.states.get(FAN_BEDROOM)
     assert state.state == "on"
     assert state.attributes["preset_mode"] == MODE_MANUAL_1
 
@@ -65,7 +65,7 @@ async def test_inactive_areas_excluded(hass: HomeAssistant) -> None:
     await _setup(hass)
     for n in (1, 2, 3):
         assert hass.states.get(f"fan.area_{n}") is None
-        assert hass.states.get("fan.kein_name") is None
+        assert hass.states.get("fan.no_name") is None
 
 
 async def test_turn_off(hass: HomeAssistant) -> None:
@@ -76,7 +76,7 @@ async def test_turn_off(hass: HomeAssistant) -> None:
         await hass.services.async_call(
             FAN_DOMAIN,
             "turn_off",
-            {"entity_id": FAN_SCHLAFZIMMER},
+            {"entity_id": FAN_BEDROOM},
             blocking=True,
         )
     mock_client.async_set_area_mode.assert_called_once_with(TEST_DEVICE_ID, 4, MODE_FANS_OFF)
@@ -88,7 +88,7 @@ async def test_set_preset_boost(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         FAN_DOMAIN,
         "set_preset_mode",
-        {"entity_id": FAN_SCHLAFZIMMER, "preset_mode": MODE_BOOST},
+        {"entity_id": FAN_BEDROOM, "preset_mode": MODE_BOOST},
         blocking=True,
     )
     mock_client.async_set_area_mode.assert_called_once_with(TEST_DEVICE_ID, 4, MODE_BOOST)
@@ -101,7 +101,7 @@ async def test_set_percentage(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         FAN_DOMAIN,
         "set_percentage",
-        {"entity_id": FAN_SCHLAFZIMMER, "percentage": 33},
+        {"entity_id": FAN_BEDROOM, "percentage": 33},
         blocking=True,
     )
     called_mode = mock_client.async_set_area_mode.call_args[0][2]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -40,7 +40,7 @@ async def _setup(hass: HomeAssistant):
 async def test_boost_switches_created(hass: HomeAssistant) -> None:
     """One boost switch per active area (entity IDs prefixed with device name)."""
     await _setup(hass)
-    for label in ("schlafzimmer_boost", "kinderzimmer_boost", "wohnzimmer_boost"):
+    for label in ("bedroom_boost", "kids_room_boost", "living_room_boost"):
         state = hass.states.get(f"switch.test_home_{label}")
         assert state is not None, f"Missing switch.test_home_{label}"
 
@@ -48,7 +48,7 @@ async def test_boost_switches_created(hass: HomeAssistant) -> None:
 async def test_boost_initial_state_off(hass: HomeAssistant) -> None:
     """Boost switch is off when current mode is not Boost ventilation."""
     await _setup(hass)
-    state = hass.states.get("switch.test_home_schlafzimmer_boost")
+    state = hass.states.get("switch.test_home_bedroom_boost")
     assert state.state == "off"
 
 
@@ -58,7 +58,7 @@ async def test_boost_turn_on(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         SWITCH_DOMAIN,
         "turn_on",
-        {"entity_id": "switch.test_home_schlafzimmer_boost"},
+        {"entity_id": "switch.test_home_bedroom_boost"},
         blocking=True,
     )
     mock_client.async_set_area_mode.assert_called_once_with(TEST_DEVICE_ID, 4, MODE_BOOST)
@@ -70,7 +70,7 @@ async def test_boost_turn_off(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         SWITCH_DOMAIN,
         "turn_off",
-        {"entity_id": "switch.test_home_schlafzimmer_boost"},
+        {"entity_id": "switch.test_home_bedroom_boost"},
         blocking=True,
     )
     mock_client.async_set_area_mode.assert_called_once_with(TEST_DEVICE_ID, 4, MODE_MANUAL_1)


### PR DESCRIPTION
Closes #3 

Replace German room labels (Schlafzimmer, Kinderzimmer, Wohnzimmer, Kein Name) with English equivalents (Bedroom, Kids Room, Living Room, No Name) throughout test fixtures and assertions.

Also update the example comment in fan.py to use an English label.